### PR TITLE
feat(cicd): Add docker-compose with env config and ci/cd with GitHub Actions

### DIFF
--- a/.env.signing.example
+++ b/.env.signing.example
@@ -1,0 +1,17 @@
+# Signing Service Environment Template
+# Copy to .env.signing and fill in secrets, or use GitHub Actions to render
+
+# Port configuration
+PORT=4006
+
+# HTTPS configuration (disabled for Docker network internal communication)
+ENABLE_HTTPS_FOR_DEV=false
+
+# Tenant signing seeds - These come from GitHub Secrets
+# Pattern: TENANT_SEED_[tenant name]
+# Set to 'generate' to create a new seed on startup (will not persist!)
+TENANT_SEED_DEFAULT=${SIGN_TENANT_SEED_DEFAULT}
+TENANT_SEED_TESTING=${SIGN_TENANT_SEED_TESTING}
+
+# Additional tenants can be added as needed:
+# TENANT_SEED_MYORG=${SIGN_TENANT_SEED_MYORG}

--- a/.env.transaction.example
+++ b/.env.transaction.example
@@ -1,0 +1,22 @@
+# Transaction Service Environment Template
+# Copy to .env.transaction and fill in secrets, or use GitHub Actions to render
+
+# Internal service URLs (using Docker DNS names)
+DEFAULT_EXCHANGE_HOST=http://localhost:4004
+REDIS_URI=redis://redis:6379
+STATUS_SERVICE=http://signing-service:4006
+
+# Cache write delay (milliseconds)
+KEYV_WRITE_DELAY=50
+
+# Tenant authentication tokens - From GitHub Secrets
+TENANT_TOKEN_DEFAULT=${API_TENANT_TOKEN_DEFAULT}
+TENANT_TOKEN_TESTING=${API_TENANT_TOKEN_TESTING}
+
+# OAuth2 JWT signing secret - From GitHub Secrets
+ACCESS_JWT_SECRET=${API_ACCESS_JWT_SECRET}
+
+# Optional: multiple issuer instances per tenant
+# TENANT_ISSUER_1_ID_EDDSATEST=did:web:example.com
+# TENANT_ISSUER_1_CRYPTOSUITE_EDDSATEST=eddsa-rdfc-2022
+# TENANT_ISSUER_1_SIGNING_TENANT_EDDSATEST=eddsatest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,117 @@
+name: Deploy to POC Server
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to deploy (branch, tag, or SHA)'
+        required: true
+        default: 'main'
+
+env:
+  DEPLOY_HOST: ${{ vars.SSH_HOST }}
+  DEPLOY_USER: ${{ vars.SSH_USER }}
+  DEPLOY_DIR: /opt/digital-badges
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ env.DEPLOY_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Render environment files
+        run: |
+          # Render signing service env file
+          cat > .env.signing << 'EOF'
+          # Auto-generated from template - DO NOT EDIT MANUALLY
+          PORT=4006
+          ENABLE_HTTPS_FOR_DEV=false
+          TENANT_SEED_DEFAULT=${{ secrets.SIGN_TENANT_SEED_DEFAULT }}
+          TENANT_SEED_TESTING=${{ secrets.SIGN_TENANT_SEED_TESTING }}
+          EOF
+
+          # Render transaction service env file
+          cat > .env.transaction << 'EOF'
+          # Auto-generated from template - DO NOT EDIT MANUALLY
+          DEFAULT_EXCHANGE_HOST=http://localhost:4004
+          REDIS_URI=redis://redis:6379
+          STATUS_SERVICE=http://signing-service:4006
+          KEYV_WRITE_DELAY=50
+          TENANT_TOKEN_DEFAULT=${{ secrets.API_TENANT_TOKEN_DEFAULT }}
+          TENANT_TOKEN_TESTING=${{ secrets.API_TENANT_TOKEN_TESTING }}
+          ACCESS_JWT_SECRET=${{ secrets.API_ACCESS_JWT_SECRET }}
+          EOF
+
+      - name: Prepare deployment package
+        run: |
+          # Create deployment directory structure
+          mkdir -p deploy
+          cp docker-compose.yml deploy/
+          cp .env.signing deploy/
+          cp .env.transaction deploy/
+          cp -r nginx deploy/
+
+          # Add deployment metadata
+          echo "DEPLOYED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > deploy/.deploy
+          echo "GIT_REF=${{ github.event.inputs.git_ref }}" >> deploy/.deploy
+          echo "GIT_SHA=$(git rev-parse HEAD)" >> deploy/.deploy
+
+      - name: Deploy to server (atomic rsync)
+        run: |
+          # Sync to staging directory on server
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            deploy/ \
+            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }}:${{ env.DEPLOY_DIR }}/staging/
+
+      - name: Activate deployment
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} << 'REMOTE_SCRIPT'
+            set -e
+
+            # Move current to rollback (for potential rollback)
+            if [ -d "${{ env.DEPLOY_DIR }}/current" ]; then
+              rm -rf "${{ env.DEPLOY_DIR }}/rollback"
+              mv "${{ env.DEPLOY_DIR }}/current" "${{ env.DEPLOY_DIR }}/rollback"
+            fi
+
+            # Move staging to current (atomic)
+            mv "${{ env.DEPLOY_DIR }}/staging" "${{ env.DEPLOY_DIR }}/current"
+
+            cd "${{ env.DEPLOY_DIR }}/current"
+
+            # Pull latest images
+            docker-compose pull
+
+            # Restart services
+            docker-compose down
+            docker-compose up -d
+
+            # Wait for services to be healthy
+            sleep 10
+
+            # Verify deployment
+            if docker-compose ps | grep -q "healthy\|Up"; then
+              echo "Deployment successful!"
+              docker-compose ps
+            else
+              echo "Deployment may have issues - check logs"
+              docker-compose logs --tail=50
+              exit 1
+            fi
+          REMOTE_SCRIPT
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf ~/.ssh/deploy_key

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ docs/reports
 # Environment files (examples are version controlled, rendered files are not)
 .env.signing
 .env.transaction
+
+# Not used except for local secret notes
+.env 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 docs/plans 
 docs/reports
 .DS_Store
+# Environment files (examples are version controlled, rendered files are not)
+.env.signing
+.env.transaction

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+
+services:
+  # Reverse proxy - entry point for all external traffic
+  nginx:
+    image: nginx:alpine
+    container_name: digital-badges-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - transaction-service
+    networks:
+      - digital-badges-network
+    restart: unless-stopped
+
+  # Transaction Service - External API for wallet flows
+  transaction-service:
+    image: skybridgeskills/dcc-transaction-service:latest
+    container_name: digital-badges-transaction
+    env_file:
+      - .env.transaction
+    depends_on:
+      - redis
+      - signing-service
+    networks:
+      - digital-badges-network
+    restart: unless-stopped
+
+  # Signing Service - Internal only, not exposed externally
+  signing-service:
+    image: skybridgeskills/dcc-signing-service:latest
+    container_name: digital-badges-signing
+    env_file:
+      - .env.signing
+    networks:
+      - digital-badges-network
+    restart: unless-stopped
+
+  # Redis - Ephemeral cache
+  redis:
+    image: redis:7-alpine
+    container_name: digital-badges-redis
+    command: redis-server --appendonly no
+    networks:
+      - digital-badges-network
+    restart: unless-stopped
+
+networks:
+  digital-badges-network:
+    driver: bridge

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,96 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Logging
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    # Basic settings
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/json application/javascript;
+
+    # Upstream definitions
+    upstream transaction_service {
+        server transaction-service:4005;
+    }
+
+    # Server block for api.digitalbadges.scot
+    server {
+        listen 80;
+        server_name api.digitalbadges.scot;
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        # Proxy all traffic to transaction service
+        location / {
+            proxy_pass http://transaction_service;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # WebSocket support (if needed)
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            # Timeouts
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+    }
+
+    # Future: status.digitalbadges.scot
+    # server {
+    #     listen 80;
+    #     server_name status.digitalbadges.scot;
+    #     # ... status page configuration
+    # }
+
+    # Future: wildcard for organization subdomains
+    # server {
+    #     listen 80;
+    #     server_name *.digitalbadges.scot;
+    #     # ... org-specific routing
+    # }
+
+    # Default server (catch-all)
+    server {
+        listen 80 default_server;
+        server_name _;
+
+        location / {
+            return 404;
+        }
+    }
+}


### PR DESCRIPTION
## Next Steps (Before First Deployment)

Configure GitHub Secrets (Repository Settings > Secrets and variables):

- [x] SSH_PRIVATE_KEY - Your SSH key
- [x] SIGN_TENANT_SEED_DEFAULT - Signing seed (keep safe!)
- [x] SIGN_TENANT_SEED_TESTING
- [x] API_ACCESS_JWT_SECRET
- [x] API_TENANT_TOKEN_DEFAULT
- [x] API_TENANT_TOKEN_TESTING
- [x] Variable: SSH_HOST
- [x] Variable: SSH_USER

Set up Server:

- [x] Add SSH public key to `~/.ssh/authorized_keys`
- [x] Create /opt/digital-badges directory
- [x] Install Docker

Configure DNS:

- [x] Add DNS record: api.digitalbadges.scot → digitalbadgespoc.vs.mythic-beasts.com (The DNS server at this web hoster is indeed responding with records for queries subdomains, seemingly everything we need)

Deploy:

Go to GitHub Actions > "Deploy to POC Server" > Run workflow


(This won't actually fully fully work yet, it's not all of the components, but its a start)