### PR TITLE
Try additional step to get network container download to enable nginx build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./nginx
       dockerfile: Dockerfile
+      network: host
     image: digital-badges-nginx:local
     container_name: digital-badges-nginx
     entrypoint: ["/usr/local/bin/nginx-entrypoint.sh"]


### PR DESCRIPTION
Add network: host to the nginx service's build config in docker-compose.yml so BuildKit uses the host's network stack during apk add openssl, bypassing the bridge-network path that's consistently timing out to dl-cdn.alpinelinux.org on the deploy server.