### PR TITLE
Add postgres and ACME config rendering based on github secrets

### DIFF
--- a/.env.postgres.example
+++ b/.env.postgres.example
@@ -1,13 +1,15 @@
 # Postgres Environment Template
-# Copy to .env.postgres and fill in a real password before first start.
+# Copy to .env.postgres and fill in real values. The rendered .env.postgres is
+# gitignored alongside .env.orca / .env.transaction / .env.signing / .env.acme.
 #
-# IMPORTANT: ORCA's DATABASE_URL (set in the ORCA service's env file,
-# defined by a separate plan) must use the SAME user, password, and db
-# name as the values below. The healthcheck in docker-compose.yml and
-# the init script in postgres/init/ also reference "orcaadmin" and
-# "orca" — if you change either of those names here, update those two
-# locations as well.
+# User, password, and database name must stay in sync with DATABASE_URL in
+# .env.orca (replace REPLACE_WITH_A_STRONG_SECRET with the same password).
+# Schema orca_public is created by postgres/init/01-orca-db-and-schemas.sql;
+# ORCA connects with ?schema=orca_public in DATABASE_URL.
 
+# ─────────────────────────────────────────────────────────────────────
+# Database credentials
+# ─────────────────────────────────────────────────────────────────────
 POSTGRES_USER=orcaadmin
 POSTGRES_PASSWORD=REPLACE_WITH_A_STRONG_SECRET
 POSTGRES_DB=orca

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,37 @@ jobs:
           ACCESS_JWT_SECRET=${{ secrets.API_ACCESS_JWT_SECRET }}
           EOF
 
+          # Render postgres env file
+          cat > .env.postgres << 'EOF'
+          # Auto-generated from template - DO NOT EDIT MANUALLY
+          POSTGRES_USER=orcaadmin
+          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB=orca
+          EOF
+
+          # Render orca env file
+          cat > .env.orca << 'EOF'
+          # Auto-generated from template - DO NOT EDIT MANUALLY
+          DATABASE_SERVERLESS="false"
+          DATABASE_URL="postgresql://orcaadmin:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/orca?schema=orca_public"
+          DATABASE_URL_DIRECT="postgresql://orcaadmin:${{ secrets.POSTGRES_PASSWORD }}@postgres:5432/orca?schema=orca_public"
+          PUBLIC_HTTP_PROTOCOL="https"
+          USE_SECURE_COOKIES="true"
+          DEFAULT_ORG_ENABLED="false"
+          DEFAULT_ORG_DOMAIN=""
+          PUBLIC_MEDIA_DOMAIN="/media"
+          ORG_CONFIG_ENCRYPTION_KEY=${{ secrets.ORCA_ORG_CONFIG_ENCRYPTION_KEY }}
+          EOF
+
+          # Render acme env file
+          cat > .env.acme << 'EOF'
+          # Auto-generated from template - DO NOT EDIT MANUALLY
+          MYTHICBEASTS_USERNAME="${{ secrets.ACME_MYTHICBEASTS_USERNAME }}"
+          MYTHICBEASTS_PASSWORD="${{ secrets.ACME_MYTHICBEASTS_PASSWORD }}"
+          LE_EMAIL="${{ secrets.ACME_LE_EMAIL }}"
+          ACME_DOMAIN_LIST="-d digitalbadges.scot -d *.digitalbadges.scot"
+          EOF
+
       - name: Prepare deployment package
         run: |
           # Create deployment directory structure
@@ -60,6 +91,9 @@ jobs:
           cp docker-compose.yml deploy/
           cp .env.signing deploy/
           cp .env.transaction deploy/
+          cp .env.orca deploy/
+          cp .env.postgres deploy/
+          cp .env.acme deploy/
           cp -r nginx deploy/
 
           # Add deployment metadata

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ Application services (for example ORCA and the DCC stack) ship as **published
 Docker images**; compose, ingress, and env configuration here reference those
 images rather than embedding primary application source code.
 
+## CI / GitHub Actions deployment
+
+The workflow [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) renders env files and rsyncs them to the PoC server. Configure **repository variables** (Settings → Secrets and variables → Actions → Variables):
+
+- `SSH_HOST` — deploy target hostname or IP
+- `SSH_USER` — SSH user for rsync and remote `docker compose`
+
+Configure **repository secrets** (Settings → Secrets and variables → Actions → Repository secrets). Existing signing/transaction secrets are documented in the workflow file; additionally set:
+
+| Secret | Purpose |
+| ------ | ------- |
+| `POSTGRES_PASSWORD` | Postgres superuser password for `orcaadmin`. **Use a URL-safe value** (e.g. `openssl rand -hex 24`) — it is embedded in ORCA’s `DATABASE_URL`. |
+| `ORCA_ORG_CONFIG_ENCRYPTION_KEY` | 32 random bytes, base64. `openssl rand -base64 32` — encrypts per-org API keys at rest in ORCA. |
+| `ACME_MYTHICBEASTS_USERNAME` | Mythic Beasts DNS API key id |
+| `ACME_MYTHICBEASTS_PASSWORD` | Mythic Beasts DNS API secret |
+| `ACME_LE_EMAIL` | Let’s Encrypt account email |
+
+After a successful run, verify on the host:
+
+1. `ls /opt/digital-badges/current/.env.*` lists `.env.signing`, `.env.transaction`, `.env.orca`, `.env.postgres`, and `.env.acme`.
+2. `cd /opt/digital-badges/current && docker compose ps` — `orca` and `postgres` **healthy**, other app services **Up**.
+3. Optional: run `./scripts/issue-certs.sh` from that directory for TLS (`.env.acme` is deployed by CI).
+
 ## Hostname routing
 
 | Host | Routes to |


### PR DESCRIPTION
@dajbelshaw this will need you to confirm a username/password for the mythic beasts control panel so that we can issue SSL certs. 

https://www.mythic-beasts.com/support/api/auth see documentation. You should be able to add an API Key and then set the "username" (variable) and "password" (secret) env vars in https://github.com/dynamicskillset/digital-badges-poc/settings/secrets/actions

I have already created the var and secret `ACME_MYTHICBEASTS_PASSWORD` and var `ACME_MYTHICBEASTS_USERNAME` for you to overwrite.