### PR TITLE
fix(compose): use 127.0.0.1 for orca healthcheck probe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     volumes:
       - orca-uploads:/app/dev-uploads
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/healthz"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/healthz"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
BusyBox wget in the Alpine-based orca image resolves `localhost` to
IPv6 `::1` first, but the SvelteKit adapter-node server binds only
IPv4 `0.0.0.0:3000`, so the healthcheck failed at TCP connect and
`nginx.depends_on.orca.condition: service_healthy` blocked the CI
deploy indefinitely. Switching the probe URL to `127.0.0.1` avoids
the IPv6 path entirely while preserving the strict `--spider -q`
semantics installed by the previous compose-healthchecks plan.