### PR TITLE
Feature/fix acme

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
           # Auto-generated from template - DO NOT EDIT MANUALLY
           MYTHICBEASTS_USERNAME="${{ vars.ACME_MYTHICBEASTS_USERNAME }}"
           MYTHICBEASTS_PASSWORD="${{ secrets.ACME_MYTHICBEASTS_PASSWORD }}"
-          LE_EMAIL="${{ secrets.ACME_LE_EMAIL }}"
+          LE_EMAIL="${{ vars.ACME_LE_EMAIL }}"
           ACME_DOMAIN_LIST="-d digitalbadges.scot -d *.digitalbadges.scot"
           EOF
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
           cp .env.postgres deploy/
           cp .env.acme deploy/
           cp -r nginx deploy/
+          cp -r scripts deploy/
 
           # Add deployment metadata
           echo "DEPLOYED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > deploy/.deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       git_ref:
-        description: 'Git ref to deploy (branch, tag, or SHA)'
+        description: "Git ref to deploy (branch, tag, or SHA)"
         required: true
-        default: 'main'
+        default: "main"
 
 env:
   DEPLOY_HOST: ${{ vars.SSH_HOST }}
@@ -85,7 +85,7 @@ jobs:
           # Render acme env file
           cat > .env.acme << 'EOF'
           # Auto-generated from template - DO NOT EDIT MANUALLY
-          MYTHICBEASTS_USERNAME="${{ secrets.ACME_MYTHICBEASTS_USERNAME }}"
+          MYTHICBEASTS_USERNAME="${{ vars.ACME_MYTHICBEASTS_USERNAME }}"
           MYTHICBEASTS_PASSWORD="${{ secrets.ACME_MYTHICBEASTS_PASSWORD }}"
           LE_EMAIL="${{ secrets.ACME_LE_EMAIL }}"
           ACME_DOMAIN_LIST="-d digitalbadges.scot -d *.digitalbadges.scot"
@@ -107,8 +107,8 @@ jobs:
           echo "DEPLOYED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > deploy/.deploy
           echo "GIT_REF=${{ github.event.inputs.git_ref }}" >> deploy/.deploy
           echo "GIT_SHA=$(git rev-parse HEAD)" >> deploy/.deploy
-      
-      - name: Install rsync                                                   
+
+      - name: Install rsync
         run: sudo apt-get install -y rsync
 
       - name: Deploy to server (atomic rsync)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ docs/plans
 docs/plans-old
 docs/reports
 .DS_Store
+mermaid-filter.err
+
 # Environment files (examples are version controlled, rendered files are not)
 .env.signing
 .env.transaction

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ images rather than embedding primary application source code.
 
 The workflow [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) renders env files and rsyncs them to the PoC server. Configure **repository variables** (Settings → Secrets and variables → Actions → Variables):
 
-- `SSH_HOST` — deploy target hostname or IP
-- `SSH_USER` — SSH user for rsync and remote `docker compose`
+| Variable | Purpose |
+| -------- | ------- |
+| `SSH_HOST` | Deploy target hostname or IP |
+| `SSH_USER` | SSH user for rsync and remote `docker compose` |
+| `ACME_MYTHICBEASTS_USERNAME` | Mythic Beasts DNS API key id (non-sensitive identifier; pairs with the API secret below) |
+| `ACME_LE_EMAIL` | Let's Encrypt account email (non-sensitive; used for expiry notifications) |
 
 Configure **repository secrets** (Settings → Secrets and variables → Actions → Repository secrets). Existing signing/transaction secrets are documented in the workflow file; additionally set:
 
@@ -19,9 +23,7 @@ Configure **repository secrets** (Settings → Secrets and variables → Actions
 | ------ | ------- |
 | `POSTGRES_PASSWORD` | Postgres superuser password for `orcaadmin`. **Use a URL-safe value** (e.g. `openssl rand -hex 24`) — it is embedded in ORCA’s `DATABASE_URL`. |
 | `ORCA_ORG_CONFIG_ENCRYPTION_KEY` | 32 random bytes, base64. `openssl rand -base64 32` — encrypts per-org API keys at rest in ORCA. |
-| `ACME_MYTHICBEASTS_USERNAME` | Mythic Beasts DNS API key id |
 | `ACME_MYTHICBEASTS_PASSWORD` | Mythic Beasts DNS API secret |
-| `ACME_LE_EMAIL` | Let’s Encrypt account email |
 
 After a successful run, verify on the host:
 
@@ -34,10 +36,10 @@ After a successful run, verify on the host:
 | Host | Routes to |
 | ---- | --------- |
 | `api.digitalbadges.scot` | `transaction-service` (via nginx → `transaction-service:4004`) |
+| `digitalbadges.scot` (apex) | `orca` (via nginx → `orca:3000`) |
 | `*.digitalbadges.scot` (any non-apex subdomain) | `orca` (via nginx → `orca:3000`) |
-| `digitalbadges.scot` (apex) | `404` from nginx default server (reserved for a future static landing) |
 
-`api.digitalbadges.scot` is matched by an exact `server_name` in nginx, so it is **not** covered by the wildcard that sends other subdomains to ORCA. The apex host is not in the ORCA `server_name` list, so it hits the `default_server` catch-all and returns `404`.
+`api.digitalbadges.scot` is matched by an exact `server_name` in nginx, so it is **not** covered by the wildcard that sends other subdomains to ORCA. The apex `digitalbadges.scot` is listed explicitly in the same `server_name` block as the wildcard (nginx wildcards do not match the bare apex), so apex traffic reaches ORCA on the same TLS vhost as tenant subdomains. Unknown hosts still hit the `default_server` catch-all and return `404`.
 
 ### Local testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Reverse proxy - entry point for all external traffic
   nginx:
@@ -10,6 +8,7 @@ services:
     image: digital-badges-nginx:local
     container_name: digital-badges-nginx
     entrypoint: ["/usr/local/bin/nginx-entrypoint.sh"]
+    command: ["nginx", "-g", "daemon off;"]
     ports:
       - "80:80"
       - "443:443"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ This app provided a learner-facing claim UI tied tightly to the DCC Admin Dashbo
 
 These host names are targets for routing; DNS, certificates, and hardening follow implementation.
 
-**ORCA** Org-specific subdomains `<org>.digitalbadges.scot` — Staff admin, learner claim and credential management, credential registry. Tenant-specific subdomain for each organization and staff.
+**ORCA** Apex `digitalbadges.scot` and org-specific subdomains `<org>.digitalbadges.scot` — Staff admin, learner claim and credential management, credential registry. Apex and tenant subdomains share the same nginx vhost; apex requests resolve to whichever `Organization` row is configured for the apex host, and unknown hosts fall through to the nginx `default_server` 404.
 
 **DCC Transaction Service** `api.digitalbadges.scot` — Wallet-facing exchange and related APIs.
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,7 +43,7 @@ http {
     # ─────────────────────────────────────────────────────────────────────
     server {
         listen 80;
-        server_name api.digitalbadges.scot *.digitalbadges.scot;
+        server_name digitalbadges.scot api.digitalbadges.scot *.digitalbadges.scot;
 
         location /.well-known/acme-challenge/ {
             # Reserved for ACME HTTP-01 fallback. Currently unused.
@@ -110,7 +110,7 @@ http {
     server {
         listen 443 ssl;
         http2 on;
-        server_name *.digitalbadges.scot;
+        server_name digitalbadges.scot *.digitalbadges.scot;
 
         ssl_certificate     /etc/nginx/certs/digitalbadges.scot.fullchain.pem;
         ssl_certificate_key /etc/nginx/certs/digitalbadges.scot.key.pem;


### PR DESCRIPTION
fix(nginx): stop nginx restart loop and prepare for wildcard TLS issuance
- compose: add nginx command: so Compose entrypoint override does not
  drop the image default CMD; drop obsolete top-level version: line
- nginx: route apex digitalbadges.scot to ORCA alongside
  *.digitalbadges.scot (wildcards do not match bare apex)
- deploy.yml: include scripts/ in the rsync payload so
  issue-certs.sh exists under /opt/digital-badges/current/
- docs: README hostname routing and CI vars/secrets updated;
  architecture.md PoC hostnames gains apex row