### PR TITLE
Add self-hosted Postfix SMTP service for ORCA email on the PoC stack

### DIFF
--- a/.env.mail.example
+++ b/.env.mail.example
@@ -1,0 +1,54 @@
+# Mail (Postfix) Environment Template
+# Copy to .env.mail and fill in real values. The rendered .env.mail is
+# gitignored alongside .env.transaction / .env.signing / .env.orca /
+# .env.postgres / .env.acme, and is re-rendered by CI from GH Actions
+# secrets on every deploy.
+#
+# The mail service (boky/postfix) runs send-only: it accepts
+# authenticated SMTP from ORCA on the compose bridge and delivers
+# outbound either direct-to-MX (default) or via a smarthost relay
+# (optional; set RELAYHOST below).
+
+# ─────────────────────────────────────────────────────────────────────
+# Inbound SMTP AUTH (from ORCA)
+# ─────────────────────────────────────────────────────────────────────
+# These values must match SMTP_USER / SMTP_PASSWORD in .env.orca so
+# ORCA can authenticate to this service. Password should be a long
+# random string. Generate locally with e.g.:
+#   openssl rand -hex 24
+SMTP_USERNAME=""
+SMTP_PASSWORD=""
+
+# ─────────────────────────────────────────────────────────────────────
+# Sender restrictions
+# ─────────────────────────────────────────────────────────────────────
+# Tenant Organization.email values may legitimately be third-party
+# domains (e.g. pilot@somecouncil.gov.uk), so we don't restrict sender
+# domains here. The envelope sender is rewritten to
+# notifications@digitalbadges.scot regardless (see sender_canonical
+# below), which is what actually matters for SPF / bounces.
+ALLOW_EMPTY_SENDER_DOMAINS=1
+
+# ─────────────────────────────────────────────────────────────────────
+# Envelope sender rewrite (do not change these)
+# ─────────────────────────────────────────────────────────────────────
+# Forces the RFC 5321 MAIL FROM on outbound mail to
+# notifications@digitalbadges.scot so bounces / DSNs come back to a
+# domain we own. The RFC 5322 From: header is untouched.
+# The map file is mounted into the container at
+# /etc/postfix/sender_canonical by docker-compose.yml.
+POSTFIX_sender_canonical_classes=envelope_sender
+POSTFIX_sender_canonical_maps=regexp:/etc/postfix/sender_canonical
+
+# ─────────────────────────────────────────────────────────────────────
+# Outbound relay (optional escape hatch)
+# ─────────────────────────────────────────────────────────────────────
+# Leave RELAYHOST unset for direct-to-MX delivery (the PoC default).
+# Set all three to route all outbound mail via a smarthost if the
+# hosting provider blocks outbound :25 or deliverability proves
+# unworkable. See plan docs/plans/2026-04-26-orca-self-hosted-smtp/
+# Q14 for rationale.
+# RELAYHOST="smtp.example.net:587"
+# RELAYHOST_USERNAME=""
+# RELAYHOST_PASSWORD=""
+# RELAYHOST_TLS_LEVEL="encrypt"

--- a/.env.orca.example
+++ b/.env.orca.example
@@ -49,8 +49,26 @@ DEFAULT_ORG_ENABLED="false"
 DEFAULT_ORG_DOMAIN=""
 
 # ─────────────────────────────────────────────────────────────────────
-# Email - deferred (Mailgun / SMTP in PoC follow-on plan)
+# Email - SMTP via the in-compose "mail" service (self-hosted Postfix)
 # ─────────────────────────────────────────────────────────────────────
+# ORCA selects its mail transport by precedence (see
+# orca/src/lib/email/sendEmail.ts):
+#   1. MAILGUN_API_KEY set and != "none"  -> Mailgun
+#   2. SMTP_HOST set                      -> SMTP (this block)
+#   3. otherwise                          -> nodemailer jsonTransport
+# For the PoC we use SMTP; leave Mailgun disabled via the "none"
+# sentinel and point SMTP_* at the in-compose mail service.
+MAILGUN_API_KEY="none"
+MAILGUN_DOMAIN=""
+MAILGUN_HOST=""
+
+SMTP_HOST="mail"
+SMTP_PORT="587"
+SMTP_SECURE="false"
+# SMTP_USER / SMTP_PASSWORD must match SMTP_USERNAME / SMTP_PASSWORD
+# in .env.mail. CI renders both from the same two GH Actions secrets.
+SMTP_USER=""
+SMTP_PASSWORD=""
 
 # ─────────────────────────────────────────────────────────────────────
 # Media - filesystem-backed via the orca-uploads named volume

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,14 @@ jobs:
           DEFAULT_ORG_DOMAIN=""
           PUBLIC_MEDIA_DOMAIN="/media"
           ORG_CONFIG_ENCRYPTION_KEY=${{ secrets.ORCA_ORG_CONFIG_ENCRYPTION_KEY }}
+          MAILGUN_API_KEY="none"
+          MAILGUN_DOMAIN=""
+          MAILGUN_HOST=""
+          SMTP_HOST="mail"
+          SMTP_PORT="587"
+          SMTP_SECURE="false"
+          SMTP_USER=${{ secrets.MAIL_SMTP_USERNAME }}
+          SMTP_PASSWORD=${{ secrets.MAIL_SMTP_PASSWORD }}
           EOF
 
           # Render acme env file. MB_AK / MB_AS are the env var names the
@@ -96,6 +104,24 @@ jobs:
           ACME_DOMAIN_LIST="-d digitalbadges.scot -d *.digitalbadges.scot"
           EOF
 
+          # Render mail env file. boky/postfix reads SMTP_USERNAME /
+          # SMTP_PASSWORD for inbound AUTH (used by ORCA on the compose
+          # bridge). POSTFIX_sender_canonical_* and
+          # ALLOW_EMPTY_SENDER_DOMAINS are configuration-only values
+          # that don't depend on secrets; they are kept here so the
+          # rendered file is self-contained (not split across template
+          # and secret). RELAYHOST (smarthost) is intentionally not
+          # rendered in CI: the PoC default is direct-to-MX, and any
+          # smarthost override is a host-side operator decision.
+          cat > .env.mail << 'EOF'
+          # Auto-generated from template - DO NOT EDIT MANUALLY
+          SMTP_USERNAME=${{ secrets.MAIL_SMTP_USERNAME }}
+          SMTP_PASSWORD=${{ secrets.MAIL_SMTP_PASSWORD }}
+          ALLOW_EMPTY_SENDER_DOMAINS=1
+          POSTFIX_sender_canonical_classes=envelope_sender
+          POSTFIX_sender_canonical_maps=regexp:/etc/postfix/sender_canonical
+          EOF
+
       - name: Prepare deployment package
         run: |
           # Create deployment directory structure
@@ -105,6 +131,7 @@ jobs:
           cp .env.transaction deploy/
           cp .env.orca deploy/
           cp .env.postgres deploy/
+          cp .env.mail deploy/
           cp .env.acme deploy/
           cp -r nginx deploy/
           cp -r scripts deploy/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ mermaid-filter.err
 .env.transaction
 .env.postgres
 .env.orca
+.env.mail
 .env.acme
 
 # Not used except for local secret notes

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Configure **repository secrets** (Settings → Secrets and variables → Actions
 | `POSTGRES_PASSWORD` | Postgres superuser password for `orcaadmin`. **Use a URL-safe value** (e.g. `openssl rand -hex 24`) — it is embedded in ORCA’s `DATABASE_URL`. |
 | `ORCA_ORG_CONFIG_ENCRYPTION_KEY` | 32 random bytes, base64. `openssl rand -base64 32` — encrypts per-org API keys at rest in ORCA. |
 | `ACME_MYTHICBEASTS_PASSWORD` | Mythic Beasts DNS API secret |
+| `MAIL_SMTP_USERNAME` | Inbound SMTP AUTH username on the in-compose `mail` service (Postfix). Used by both `.env.mail` (`SMTP_USERNAME`) and `.env.orca` (`SMTP_USER`). Any opaque string. |
+| `MAIL_SMTP_PASSWORD` | Inbound SMTP AUTH password for the above username. Generate with e.g. `openssl rand -hex 24`. |
 
 After a successful run, verify on the host:
 
-1. `ls /opt/digital-badges/current/.env.*` lists `.env.signing`, `.env.transaction`, `.env.orca`, `.env.postgres`, and `.env.acme`.
-2. `cd /opt/digital-badges/current && docker compose ps` — `orca` and `postgres` **healthy**, other app services **Up**.
+1. `ls /opt/digital-badges/current/.env.*` lists `.env.signing`, `.env.transaction`, `.env.orca`, `.env.mail`, `.env.postgres`, and `.env.acme`.
+2. `cd /opt/digital-badges/current && docker compose ps` — `orca` and `postgres` **healthy**, other app services (including `mail`) **Up**.
 3. Optional: run `./scripts/issue-certs.sh` from that directory for TLS (`.env.acme` is deployed by CI).
 
 ## Hostname routing
@@ -147,7 +149,7 @@ docker compose exec postgres psql -U orcaadmin orca
 
 ## Troubleshooting
 
-- **Logs:** follow a service with `docker compose logs -f <service>` where `<service>` is one of `nginx`, `orca`, `postgres`, `transaction-service`, `signing-service`, or `redis`. (The `acme` service is usually invoked with `docker compose run` rather than left running.)
+- **Logs:** follow a service with `docker compose logs -f <service>` where `<service>` is one of `nginx`, `orca`, `postgres`, `mail`, `transaction-service`, `signing-service`, or `redis`. (The `acme` service is usually invoked with `docker compose run` rather than left running.)
 - **ORCA uploads:** filesystem-backed media lives in the **`orca-uploads`** named volume (mounted at `/app/dev-uploads` in the `orca` container). It survives `docker compose restart` and is removed only if you delete the volume (e.g. `docker compose down -v` together with other volumes).
 - **Installed certificates:** list what acme.sh has stored with  
   `docker compose run --rm -T acme --list --home /acme.sh`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      mail:
+        condition: service_started
     volumes:
       - orca-uploads:/app/dev-uploads
     healthcheck:
@@ -119,6 +121,28 @@ services:
     image: redis:7-alpine
     container_name: digital-badges-redis
     command: redis-server --appendonly no
+    networks:
+      - digital-badges-network
+    restart: unless-stopped
+
+  # Mail - Send-only SMTP relay (Postfix). Internal only, not exposed
+  # externally. ORCA connects over the compose bridge on SMTP :587
+  # with AUTH and hands off messages. Outbound behaviour:
+  #   - Default: direct-to-MX on port 25 egress from the PoC host.
+  #   - Optional smarthost: set RELAYHOST (+ RELAYHOST_USERNAME /
+  #     RELAYHOST_PASSWORD) in .env.mail to relay upstream. See the
+  #     plan in docs/plans/2026-04-26-orca-self-hosted-smtp/ for
+  #     design and deliverability notes.
+  # The envelope sender (MAIL FROM) is rewritten to
+  # notifications@digitalbadges.scot via the mounted regexp map below;
+  # the RFC 5322 From: header remains whatever the application passes.
+  mail:
+    image: boky/postfix:v5.1.0@sha256:aafc772384232497bed875e1eb66b4d3e54ba1ebc86e2e185a6dc1dbc48182ef
+    container_name: digital-badges-mail
+    env_file:
+      - .env.mail
+    volumes:
+      - ./postfix/sender_canonical:/etc/postfix/sender_canonical:ro
     networks:
       - digital-badges-network
     restart: unless-stopped

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,14 @@ Reverse proxy: routes hostnames to the right service, concentrates public ingres
 
 ORCA's persistence layer: tenant configuration, achievement definitions, and credential / claim metadata. Runs as a container on the same Docker Compose network as the application services so ORCA can reach it by service DNS name (`postgres`). Reachable only on the Docker network — not exposed via nginx and not published to the host. Schema bootstrap (`orca` database, `orca_public` schema) runs once on first start from a checked-in init script; data persists across restarts via a named Docker volume.
 
+### Mail (self-hosted Postfix, send-only)
+
+ORCA sends notifications and sign-in codes; a small Postfix container (`boky/postfix`) accepts authenticated SMTP from ORCA on the Compose bridge and delivers outbound either direct-to-MX or via an optional smarthost relay configured through environment variables. It is send-only: it does not accept inbound mail for any mailbox.
+
+The envelope sender is rewritten to `notifications@digitalbadges.scot` on outbound, while the RFC 5322 `From:` header is left as the tenant organisation's own address so replies reach the organisation.
+
+Deliverability on a fresh PoC VM without SPF, DKIM, DMARC, or matching rDNS will be inconsistent; the smarthost relay is the documented escape hatch when direct-to-MX is blocked or deliverability is insufficient.
+
 These services are intended to run as containers on a Docker Compose network, so they share a private network namespace while nginx remains the controlled entry point from the internet. In a production deployment, these services could be run as load-balanced horizontally scalable tasks behind an application load balancer and internet gateway.
 
 ```{=latex}
@@ -60,13 +68,17 @@ flowchart TB
     TxService["Transaction Service (api subdomain)"]
     Future["future: VerifierPlus, OIDF registry on reserved subdomains"]
     Postgres["Postgres (internal only)"]
+    Mail["Mail (internal; send-only SMTP)"]
   end
 
   TxService --> Signing
   ORCA --> Postgres
+  ORCA -->|"SMTP :587 with AUTH"| Mail
   ORCA -.->|"coordinates / uses for exchange flows"| TxService
 
   Signing["Signing Service (internal only)"]
+  Internet["Recipient MX servers"]
+  Mail -.->|"SMTP :25 (direct-to-MX) or smarthost :587"| Internet
 ```
 
 ## Alternatives and ecosystem review
@@ -115,7 +127,14 @@ These host names are targets for routing; DNS, certificates, and hardening follo
 
 **OIDF issuer registry** `registry.digitalbadges.scot` — Future self-hosted registry; production trust when wallet integration is ready.
 
-The Signing Service is reachable only on the Docker network (e.g. service hostname internal to Compose), not via a public vhost.
+The Signing Service and the Mail service (self-hosted Postfix, send-only) are reachable only on the Docker network; neither has a public vhost.
+
+### Deliverability caveats
+
+- Many cloud and VPS providers block outbound port 25 by default; if that is the case on the PoC host, the smarthost relay (`RELAYHOST` in `.env.mail`) is the documented escape hatch.
+- The PoC domain does not yet publish SPF, DKIM, or DMARC records; mail from the PoC VM IP is therefore likely to land in spam or be rejected by strict receivers until those records are added (out of scope for this repo).
+- Bounces and DSNs return to `notifications@digitalbadges.scot` (envelope sender rewritten by the mail service); the RFC 5322 `From:` header preserved from the application (the organisation's address) is what users see and reply to.
+- Mail is not part of the public ingress plane; no hostname or public port is allocated.
 
 ## Trust and holder components (adjacent to Compose)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,36 +1,37 @@
 # Security Architecture
 
-TODO: Refine the content on this page and create an implementation tracking checklist where we can reference how we are performing each thing. Cleanup the not quite good markdown formatting.
+TODO: Refine the content on this page and create an implementation tracking checklist where we can
+reference how we are performing each thing. Cleanup the not quite good markdown formatting.
 
-Dynamic Skillset Ltd and Skybridge Skills commit to implementing and maintaining the five technical controls specified by the Cyber Essentials scheme throughout contract delivery, in accordance with Procurement Policy Note 09/14 which permits demonstration of equivalent controls through independent third-party verification.
+Dynamic Skillset Ltd and Skybridge Skills commit to implementing and maintaining the five technical
+controls specified by the Cyber Essentials scheme throughout contract delivery, in accordance with
+Procurement Policy Note 09/14 which permits demonstration of equivalent controls through independent
+third-party verification.
 
 ## The Five Technical Controls
 
-1. Firewalls and Internet Gateways
-   All development and deployment systems protected by configured firewalls
-   Planned PoC ingress: public HTTPS terminated at an **nginx** reverse proxy routing to application containers (see [Architecture](./architecture.md))
-   Unnecessary ports closed with documented port management
-   Remote access restricted to authorised IP addresses
+1. Firewalls and Internet Gateways All development and deployment systems protected by configured
+   firewalls Planned PoC ingress: public HTTPS terminated at an **nginx** reverse proxy routing to
+   application containers (see [Architecture](./architecture.md)) Unnecessary ports closed with
+   documented port management
+   - The mail service (Postfix) does not publish any host ports; SMTP submission is reachable only
+   from other containers on the Compose network. Remote access restricted to authorised IP addresses
    Regular firewall rule audits
-2. Secure Configuration
-   Systems configured to security baselines with default passwords changed
-   Unnecessary software and services disabled
-   Strong password policies enforced (minimum 12 characters, complexity requirements)
-   Multi-factor authentication where supported
-   Auto-run and auto-execute features disabled
-3. User Access Control
-   Principle of least privilege applied to all accounts
-   Separate administrator accounts used only for elevated tasks
-   Standard user accounts for routine work
-   Regular access permission reviews
-   Documented access management procedures
-4. Security Update Management
-   Automated operating system updates configured
-   Third-party software patching within 14 days of security releases
-   Documented patch management process
-   Regular vulnerability scanning
-5. Malware Protection
-   Current anti-malware software on all devices
-   Automated definition updates enabled
-   Regular scheduled scans configured
-   Real-time protection active
+2. Secure Configuration Systems configured to security baselines with default passwords changed
+   Unnecessary software and services disabled Strong password policies enforced (minimum 12
+   characters, complexity requirements) Multi-factor authentication where supported Auto-run and
+   auto-execute features disabled
+   - ORCA → mail SMTP AUTH travels plaintext over the internal Docker bridge (not over the public
+     network). An adversary with sniff capability on the bridge has already compromised the host;
+     the tradeoff is accepted for PoC.
+3. User Access Control Principle of least privilege applied to all accounts Separate administrator
+   accounts used only for elevated tasks Standard user accounts for routine work Regular access
+   permission reviews Documented access management procedures
+4. Security Update Management Automated operating system updates configured Third-party software
+   patching within 14 days of security releases
+   - External Docker images in the PoC stack (including `boky/postfix`, `postgres`, `redis`,
+   `nginx`, and the DCC services) are pinned by tag and where feasible by digest; security updates
+   to upstream images are applied by bumping the pin after review. Documented patch management
+   process Regular vulnerability scanning
+5. Malware Protection Current anti-malware software on all devices Automated definition updates
+   enabled Regular scheduled scans configured Real-time protection active

--- a/postfix/sender_canonical
+++ b/postfix/sender_canonical
@@ -1,0 +1,9 @@
+# Rewrite the RFC 5321 envelope sender (MAIL FROM) on ALL outgoing mail
+# to a fixed address we control. The RFC 5322 From: header is NOT
+# touched — recipients still see the tenant's org.email.
+#
+# Referenced from docker-compose.yml (mail service) via:
+#   POSTFIX_sender_canonical_classes=envelope_sender
+#   POSTFIX_sender_canonical_maps=regexp:/etc/postfix/sender_canonical
+# No postmap(1) step is needed for regexp: maps.
+/.+/    notifications@digitalbadges.scot


### PR DESCRIPTION
Adds an internal-only `mail` service (boky/postfix, pinned by tag +
digest) to the PoC Compose stack so ORCA can send real email from the
production deployment without relying on Mailgun. Postfix accepts SMTP
AUTH from ORCA on the compose bridge, rewrites the envelope sender to
notifications@digitalbadges.scot (preserving the RFC 5322 From:
header), and delivers direct-to-MX by default with a documented
RELAYHOST smarthost fallback.

CI renders a new .env.mail from two new GH Actions secrets
(MAIL_SMTP_USERNAME, MAIL_SMTP_PASSWORD) and wires the same pair into
.env.orca as SMTP_USER / SMTP_PASSWORD so both sides agree on the
AUTH credential. Architecture, security, and README docs updated to
match. Plan archived under docs/plans-old/.