### PR TITLE
fix(nginx): increase proxy buffer sizes to fix 502 errors

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -101,6 +101,11 @@ http {
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
+
+            # Buffer sizes increased to prevent "upstream sent too big header" errors
+            proxy_buffer_size 16k;
+            proxy_buffers 4 16k;
+            proxy_busy_buffers_size 32k;
         }
     }
 
@@ -141,6 +146,11 @@ http {
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
+
+            # Buffer sizes increased to prevent "upstream sent too big header" errors
+            proxy_buffer_size 16k;
+            proxy_buffers 4 16k;
+            proxy_busy_buffers_size 32k;
         }
     }
 


### PR DESCRIPTION
Error causing nginx 502 was:

> digital-badges-nginx  | 2026/04/27 17:02:07 [error] 30#30: *392 upstream sent too big header while reading response header from upstream, client: 69.9.132.168, server: digitalbadges.scot, request: "GET /achievements/3c36ae30-8f61-4496-b776-80c2eab27617 HTTP/2.0", upstream: "http://172.18.0.7:3000/achievements/3c36ae30-8f61-4496-b776-80c2eab27617", host: "test.digitalbadges.scot"

Add proxy_buffer_size, proxy_buffers, and proxy_busy_buffers_size to both
ORCA and transaction-service location blocks. This fixes the "upstream sent
too big header" 502 errors when ORCA returns large response headers.
