### PR TITLE
Feature/improve-signing-service-healthcheck

### DIFF
--- a/.env.signing.example
+++ b/.env.signing.example
@@ -16,3 +16,7 @@ TENANT_SEED_AWARDSNETWORK=${SIGN_TENANT_SEED_AWARDSNETWORK}
 
 # Additional tenants can be added as needed:
 # TENANT_SEED_MYORG=${SIGN_TENANT_SEED_MYORG}
+
+# Health check (docker compose uses signing-service Dockerfile healthcheck.js)
+HEALTH_CHECK_SERVICE_URL=http://localhost:4006/healthz
+HEALTH_CHECK_SERVICE_NAME=signing-service

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,8 @@ jobs:
           TENANT_SEED_DEFAULT=${{ secrets.SIGN_TENANT_SEED_DEFAULT }}
           TENANT_SEED_TESTING=${{ secrets.SIGN_TENANT_SEED_TESTING }}
           TENANT_SEED_AWARDSNETWORK=${{ secrets.SIGN_TENANT_SEED_AWARDSNETWORK }}
+          HEALTH_CHECK_SERVICE_URL=http://localhost:4006/healthz
+          HEALTH_CHECK_SERVICE_NAME=signing-service
           EOF
 
           # Render transaction service env file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,13 +80,12 @@ services:
     healthcheck:
       test:
         - "CMD"
-        - "node"
-        - "-e"
-        - "require('net').createConnection(4006,'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))"
+        - "/nodejs/bin/node"
+        - "/app/healthcheck.js"
       interval: 10s
-      timeout: 3s
+      timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 30s
     networks:
       - digital-badges-network
     restart: unless-stopped


### PR DESCRIPTION
Here's what was implemented:

1. digital-badges-poc/docker-compose.yml
Signing healthcheck now runs /nodejs/bin/node /app/healthcheck.js (matches distroless paths).
Timing: timeout: 5s, start_period: 30s.
2. digital-badges-poc/.env.signing
HEALTH_CHECK_SERVICE_URL=http://localhost:4006/healthz
HEALTH_CHECK_SERVICE_NAME=signing-service
3. digital-badges-poc/.env.signing.example
Same vars documented for anyone copying from the template.
4. digital-badges-poc/.github/workflows/deploy.yml
Rendered .env.signing now includes those two variables so deploys aren’t missing them (CI overwrites .env.signing; without this, healthcheck.js would get undefined URLs).